### PR TITLE
Update wp_forms-v5.php

### DIFF
--- a/wp_forms-v5.php
+++ b/wp_forms-v5.php
@@ -25,7 +25,7 @@ class acf_field_wp_forms extends acf_field {
 			'allow_null' => 0
 		);
 
-		if ( class_exists( 'WPForms' ) ) {
+		if ( function_exists( 'wpforms' ) ) {
 			$this->forms = wpforms()->form->get( '' );
 		}
 


### PR DESCRIPTION
fix for missing 'WPForms' class after update to WPForms 1.5.0.0